### PR TITLE
Change log to slog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.24'
-          cache: 'go'
+          cache: true
 
       - name: Run unit tests
         run: make test

--- a/.run/run smtp server.run.xml
+++ b/.run/run smtp server.run.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run smtp server" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="resend-railway-gateway" />
+    <working_directory value="$PROJECT_DIR$" />
+    <envs>
+      <env name="RESEND_API_KEY" value="api-key" />
+    </envs>
+    <kind value="PACKAGE" />
+    <package value="github.com/igorrius/resend-railway-gateway/cmd/gateway" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/cmd/gateway/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
-	"time"
+	"os/signal"
+	"syscall"
 
 	resendclient "github.com/igorrius/resend-railway-gateway/internal/adapters/resend"
 	smtpserver "github.com/igorrius/resend-railway-gateway/internal/adapters/smtp"
@@ -43,10 +45,41 @@ func main() {
 	sender := resendclient.NewClient(cfg.ResendAPIKey)
 	svc := app.NewService(sender, stdLogger{}, cfg.SendTimeout)
 	server := smtpserver.NewServer(cfg.SMTPListerAddr, svc)
-	slog.Info("smtp_listen", "addr", cfg.SMTPListerAddr)
-	if err := server.ListenAndServe(); err != nil {
-		slog.Error("smtp_server_error", "error", err)
-		os.Exit(1)
+
+	// Set up signal handling for graceful shutdown
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	errCh := make(chan error, 1)
+
+	// Start server in a separate goroutine
+	go func() {
+		slog.Info("smtp_listen", "addr", cfg.SMTPListerAddr)
+		errCh <- server.ListenAndServe()
+	}()
+
+	var exitCode int
+	select {
+	case sig := <-sigCh:
+		slog.Info("shutdown_signal_received", "signal", sig.String())
+		// Attempt graceful shutdown by closing the server listener
+		if cerr := server.Close(); cerr != nil {
+			slog.Error("smtp_server_close_error", "error", cerr)
+		}
+		// Wait for ListenAndServe to return; treat closing of the listener as normal
+		err = <-errCh
+		if err != nil && !errors.Is(err, os.ErrClosed) {
+			// go-smtp may return specific errors on close; log but exit 0 since shutdown was requested
+			slog.Info("smtp_server_stopped", "error", err)
+		}
+		exitCode = 0
+	case err = <-errCh:
+		if err != nil {
+			slog.Error("smtp_server_error", "error", err)
+			exitCode = 1
+		} else {
+			exitCode = 0
+		}
 	}
-	_ = time.Now()
+
+	os.Exit(exitCode)
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -12,29 +11,17 @@ import (
 	smtpserver "github.com/igorrius/resend-railway-gateway/internal/adapters/smtp"
 	"github.com/igorrius/resend-railway-gateway/internal/app"
 	"github.com/igorrius/resend-railway-gateway/internal/config"
+	"github.com/igorrius/resend-railway-gateway/internal/logging"
 )
 
-type stdLogger struct{}
-
-func (l stdLogger) Info(msg string, fields map[string]any) {
-	attrs := make([]slog.Attr, 0, len(fields))
-	for k, v := range fields {
-		attrs = append(attrs, slog.Any(k, v))
-	}
-	slog.Default().LogAttrs(context.Background(), slog.LevelInfo, msg, attrs...)
-}
-func (l stdLogger) Error(msg string, fields map[string]any) {
-	attrs := make([]slog.Attr, 0, len(fields))
-	for k, v := range fields {
-		attrs = append(attrs, slog.Any(k, v))
-	}
-	slog.Default().LogAttrs(context.Background(), slog.LevelError, msg, attrs...)
-}
-
 func main() {
+	// create root slog logger and set as default
+	root := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(root)
+
 	cfg, err := config.Load()
 	if err != nil {
-		slog.Error("config_load_failed", "error", err)
+		root.Error("config_load_failed", "error", err)
 		os.Exit(1)
 	}
 	// optional override for Railway dynamic ports
@@ -43,7 +30,7 @@ func main() {
 	}
 
 	sender := resendclient.NewClient(cfg.ResendAPIKey)
-	svc := app.NewService(sender, stdLogger{}, cfg.SendTimeout)
+	svc := app.NewService(sender, logging.New(root), cfg.SendTimeout)
 	server := smtpserver.NewServer(cfg.SMTPListerAddr, svc)
 
 	// Set up signal handling for graceful shutdown
@@ -53,28 +40,28 @@ func main() {
 
 	// Start server in a separate goroutine
 	go func() {
-		slog.Info("smtp_listen", "addr", cfg.SMTPListerAddr)
+		root.Info("smtp_listen", "addr", cfg.SMTPListerAddr)
 		errCh <- server.ListenAndServe()
 	}()
 
 	var exitCode int
 	select {
 	case sig := <-sigCh:
-		slog.Info("shutdown_signal_received", "signal", sig.String())
+		root.Info("shutdown_signal_received", "signal", sig.String())
 		// Attempt graceful shutdown by closing the server listener
 		if cerr := server.Close(); cerr != nil {
-			slog.Error("smtp_server_close_error", "error", cerr)
+			root.Error("smtp_server_close_error", "error", cerr)
 		}
 		// Wait for ListenAndServe to return; treat closing of the listener as normal
 		err = <-errCh
 		if err != nil && !errors.Is(err, os.ErrClosed) {
 			// go-smtp may return specific errors on close; log but exit 0 since shutdown was requested
-			slog.Info("smtp_server_stopped", "error", err)
+			root.Info("smtp_server_stopped", "error", err)
 		}
 		exitCode = 0
 	case err = <-errCh:
 		if err != nil {
-			slog.Error("smtp_server_error", "error", err)
+			root.Error("smtp_server_error", "error", err)
 			exitCode = 1
 		} else {
 			exitCode = 0

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+// StdLogger wraps a *slog.Logger and adapts the domain MessageLogger
+// interface (Info, Error with map[string]any fields) to slog's Attr API.
+type StdLogger struct{ L *slog.Logger }
+
+// New returns a new StdLogger wrapping the provided slog.Logger.
+func New(l *slog.Logger) *StdLogger { return &StdLogger{L: l} }
+
+func (l *StdLogger) mapAttrs(fields map[string]any) []slog.Attr {
+	if len(fields) == 0 {
+		return nil
+	}
+	attrs := make([]slog.Attr, 0, len(fields))
+	for k, v := range fields {
+		attrs = append(attrs, slog.Any(k, v))
+	}
+	return attrs
+}
+
+func (l *StdLogger) Info(msg string, fields map[string]any) {
+	l.L.LogAttrs(context.Background(), slog.LevelInfo, msg, l.mapAttrs(fields)...)
+}
+
+func (l *StdLogger) Error(msg string, fields map[string]any) {
+	l.L.LogAttrs(context.Background(), slog.LevelError, msg, l.mapAttrs(fields)...)
+}


### PR DESCRIPTION
This pull request modernizes the logging and server lifecycle management in the SMTP gateway application. The main improvements include switching from the standard library logger to structured logging using `slog`, introducing graceful shutdown handling via OS signals, and refactoring logging logic into a dedicated package for consistency and maintainability.

**Logging improvements:**
* Replaced the legacy `log`-based logger with Go's structured `slog` logger, setting up a root JSON handler and using it as the default logger throughout the application (`cmd/gateway/main.go`).
* Introduced a new `internal/logging/logger.go` package, providing a `StdLogger` adapter to unify domain logging calls with the `slog` API. This ensures all logs are structured and consistent (`internal/logging/logger.go`).
* Updated service initialization in `main.go` to use the new `logging.StdLogger` instead of the previous custom logger implementation (`cmd/gateway/main.go`).

**Server lifecycle and shutdown handling:**
* Added signal handling for graceful shutdown (SIGINT/SIGTERM), ensuring the SMTP server closes cleanly and logs shutdown events appropriately (`cmd/gateway/main.go`).
* Improved error handling on server shutdown: the application logs errors from `ListenAndServe` and `Close`, and exits with the correct exit code depending on the shutdown reason (`cmd/gateway/main.go`).

**Development tooling:**
* Added a Run Configuration XML for running the SMTP server locally, including environment variable setup for the Resend API key (`.run/run smtp server.run.xml`).