### PR TITLE
Fix body parser

### DIFF
--- a/internal/adapters/resend/client.go
+++ b/internal/adapters/resend/client.go
@@ -25,7 +25,7 @@ func (c *Client) Send(email domain.Email) error {
 	for _, t := range email.Tags {
 		tags = append(tags, resendgo.Tag{Name: t.Name, Value: t.Value})
 	}
-	_, err := c.client.Emails.Send(&resendgo.SendEmailRequest{
+	request := &resendgo.SendEmailRequest{
 		From:        email.From,
 		To:          email.To,
 		Cc:          email.Cc,
@@ -37,7 +37,8 @@ func (c *Client) Send(email domain.Email) error {
 		Attachments: attachments,
 		Tags:        tags,
 		Headers:     email.Headers,
-	})
+	}
+	_, err := c.client.Emails.Send(request)
 	return err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,7 @@ func Load() (Config, error) {
 	if key == "" {
 		return Config{}, fmt.Errorf("RESEND_API_KEY is required")
 	}
-	addr := getenv("SMTP_LISTEN_ADDR", ":2525")
+	addr := getenv("SMTP_LISTEN_ADDR", ":1025")
 	timeoutStr := getenv("SEND_TIMEOUT_SECONDS", "15")
 	tSec, err := strconv.Atoi(timeoutStr)
 	if err != nil || tSec <= 0 {


### PR DESCRIPTION
This pull request introduces improvements to the email parsing logic in the SMTP server, refactors function naming for clarity, and makes a configuration adjustment for the default SMTP listening address. The most significant change is the enhanced MIME parsing, which now handles nested multipart structures and various content transfer encodings, ensuring emails are parsed more robustly. Additionally, the code is refactored for better readability and maintainability.

**Email parsing and handling improvements:**

* Enhanced MIME parsing in `ParseMIMEMessage` to handle both multipart and non-multipart emails, including support for base64 and quoted-printable encodings, and robust detection of body start markers. This enables more reliable extraction of text, HTML, and attachments from incoming emails.
* Added a new helper function `parseMultipartBody` to recursively parse nested multipart email content, properly extracting text, HTML, and attachments from complex MIME structures.

**Codebase refactoring:**

* Renamed `parseMIMEMessage` to `ParseMIMEMessage` and updated all references to use the new name, improving code clarity and consistency. [[1]](diffhunk://#diff-2748b4dae2be3d65f31c8205e7d49e2b139919d9e733463d61e2801718794198L46-R46) [[2]](diffhunk://#diff-2748b4dae2be3d65f31c8205e7d49e2b139919d9e733463d61e2801718794198L66-R70)
* Refactored the request creation in the Resend client to use a named variable for the email sending request, improving readability. [[1]](diffhunk://#diff-2c4e1a0fd67586da2344c7db99608de202c04adccde529d24134ff26835fccf7L28-R28) [[2]](diffhunk://#diff-2c4e1a0fd67586da2344c7db99608de202c04adccde529d24134ff26835fccf7L40-R41)

**Configuration change:**

* Changed the default value of `SMTP_LISTEN_ADDR` from `:2525` to `:1025` in the configuration loader, aligning with common local development practices.