### PR TITLE
fix: missing attachments content-type

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -24,7 +24,10 @@ func main() {
 		root.Error("config_load_failed", "error", err)
 		os.Exit(1)
 	}
-
+	// optional override for Railway dynamic ports
+	if v := os.Getenv("PORT"); v != "" {
+		cfg.SMTPListerAddr = ":" + v
+	}
 
 	sender := resendclient.NewClient(cfg.ResendAPIKey, logging.New(root))
 	svc := app.NewService(sender, logging.New(root), cfg.SendTimeout)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 
-	sender := resendclient.NewClient(cfg.ResendAPIKey)
+	sender := resendclient.NewClient(cfg.ResendAPIKey, logging.New(root))
 	svc := app.NewService(sender, logging.New(root), cfg.SendTimeout)
 	server := smtpserver.NewServer(cfg.SMTPListerAddr, svc)
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -24,10 +24,7 @@ func main() {
 		root.Error("config_load_failed", "error", err)
 		os.Exit(1)
 	}
-	// optional override for Railway dynamic ports
-	if v := os.Getenv("PORT"); v != "" {
-		cfg.SMTPListerAddr = ":" + v
-	}
+
 
 	sender := resendclient.NewClient(cfg.ResendAPIKey)
 	svc := app.NewService(sender, logging.New(root), cfg.SendTimeout)

--- a/internal/adapters/resend/client.go
+++ b/internal/adapters/resend/client.go
@@ -21,8 +21,9 @@ func (c *Client) Send(email domain.Email) error {
 	attachments := make([]*resendgo.Attachment, 0, len(email.Attachments))
 	for _, a := range email.Attachments {
 		attachments = append(attachments, &resendgo.Attachment{
-			Filename: a.Filename,
-			Content:  a.Content,
+			Filename:    a.Filename,
+			Content:     a.Content,
+			ContentType: a.ContentType,
 		})
 	}
 	tags := make([]resendgo.Tag, 0, len(email.Tags))

--- a/internal/adapters/resend/client.go
+++ b/internal/adapters/resend/client.go
@@ -9,15 +9,32 @@ import (
 // It wraps the Resend Go SDK and adapts it to the domain OutboundEmailSender interface.
 type Client struct {
 	client *resendgo.Client
+	logger domain.MessageLogger
 }
 
 // NewClient creates a new Resend client with the given API key.
-func NewClient(apiKey string) *Client {
-	return &Client{client: resendgo.NewClient(apiKey)}
+func NewClient(apiKey string, logger domain.MessageLogger) *Client {
+	return &Client{client: resendgo.NewClient(apiKey), logger: logger}
 }
 
 // Send converts the domain Email to Resend's format and sends it via the API.
 func (c *Client) Send(email domain.Email) error {
+	attachmentMeta := make([]map[string]any, 0, len(email.Attachments))
+	for _, a := range email.Attachments {
+		attachmentMeta = append(attachmentMeta, map[string]any{
+			"filename":     a.Filename,
+			"content_type": a.ContentType,
+			"size":         len(a.Content),
+		})
+	}
+	c.logger.Debug("resend_request_start", map[string]any{
+		"subject":     email.Subject,
+		"to":          email.To,
+		"text_body":   email.Text,
+		"html_body":   email.HTML,
+		"attachments": attachmentMeta,
+	})
+
 	attachments := make([]*resendgo.Attachment, 0, len(email.Attachments))
 	for _, a := range email.Attachments {
 		attachments = append(attachments, &resendgo.Attachment{
@@ -43,7 +60,12 @@ func (c *Client) Send(email domain.Email) error {
 		Tags:        tags,
 		Headers:     email.Headers,
 	}
-	_, err := c.client.Emails.Send(request)
+	resp, err := c.client.Emails.Send(request)
+	if err == nil {
+		c.logger.Debug("resend_request_success", map[string]any{
+			"id": resp.Id,
+		})
+	}
 	return err
 }
 

--- a/internal/adapters/resend/client.go
+++ b/internal/adapters/resend/client.go
@@ -25,6 +25,7 @@ func (c *Client) Send(email domain.Email) error {
 			"filename":     a.Filename,
 			"content_type": a.ContentType,
 			"size":         len(a.Content),
+			"content_id":   a.ContentID,
 		})
 	}
 	c.logger.Debug("resend_request_start", map[string]any{
@@ -41,6 +42,7 @@ func (c *Client) Send(email domain.Email) error {
 			Filename:    a.Filename,
 			Content:     a.Content,
 			ContentType: a.ContentType,
+			ContentId:   a.ContentID,
 		})
 	}
 	tags := make([]resendgo.Tag, 0, len(email.Tags))

--- a/internal/adapters/smtp/parse_test.go
+++ b/internal/adapters/smtp/parse_test.go
@@ -325,3 +325,120 @@ Attachment content
 		t.Errorf("expected default filename 'attachment', got '%s'", email.Attachments[0].Filename)
 	}
 }
+
+func TestParseMIMEMessage_InlineWithContentID(t *testing.T) {
+	boundary := "boundary12345"
+	raw := []byte(`Subject: Test
+From: sender@example.com
+Content-Type: multipart/related; boundary=` + boundary + `
+
+--` + boundary + `
+Content-Type: text/html
+
+<img src="cid:image.png">
+--` + boundary + `
+Content-Type: image/png
+Content-ID: <image.png>
+Content-Disposition: inline
+
+PNG content
+--` + boundary + `--
+`)
+
+	email := ParseMIMEMessage("sender@example.com", []string{"recipient@example.com"}, raw)
+
+	if len(email.Attachments) != 1 {
+		t.Errorf("expected 1 attachment, got %d", len(email.Attachments))
+	} else {
+		if email.Attachments[0].ContentID != "<image.png>" {
+			t.Errorf("expected ContentID '<image.png>', got '%s'", email.Attachments[0].ContentID)
+		}
+		// Should default filename to ContentID content if no filename param
+		if email.Attachments[0].Filename != "image.png" {
+			t.Errorf("expected filename 'image.png', got '%s'", email.Attachments[0].Filename)
+		}
+	}
+}
+
+func TestParseMIMEMessage_VaultwardenExample(t *testing.T) {
+	raw := []byte(`Message-ID: <test-id@example.com>
+To: recipient@example.com
+From: Vaultwarden <vaultwarden@example.com>
+Subject: Vaultwarden SMTP Test
+MIME-Version: 1.0
+Date: Fri, 28 Nov 2025 20:52:02 +0000
+Content-Type: multipart/alternative; boundary="boundary_alternative"
+
+--boundary_alternative
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+This is a test email.
+
+--boundary_alternative
+Content-Type: multipart/related; boundary="boundary_related"
+
+--boundary_related
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+<html><body>
+<img src=3D"cid:logo.png" />
+<img src=3D"cid:github.png" />
+</body></html>
+
+--boundary_related
+Content-ID: <logo.png>
+Content-Disposition: inline
+Content-Type: image/png
+Content-Transfer-Encoding: base64
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9
+awAAAABJRU5ErkJggg==
+
+--boundary_related
+Content-ID: <github.png>
+Content-Disposition: inline
+Content-Type: image/png
+Content-Transfer-Encoding: base64
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9
+awAAAABJRU5ErkJggg==
+
+--boundary_related--
+--boundary_alternative--
+`)
+
+	email := ParseMIMEMessage("vaultwarden@example.com", []string{"recipient@example.com"}, raw)
+
+	if email.Subject != "Vaultwarden SMTP Test" {
+		t.Errorf("expected subject 'Vaultwarden SMTP Test', got '%s'", email.Subject)
+	}
+
+	if len(email.Attachments) != 2 {
+		t.Errorf("expected 2 attachments, got %d", len(email.Attachments))
+	} else {
+		// Check first attachment (logo)
+		if email.Attachments[0].ContentID != "<logo.png>" {
+			t.Errorf("expected first ContentID '<logo.png>', got '%s'", email.Attachments[0].ContentID)
+		}
+		if email.Attachments[0].Filename != "logo.png" {
+			t.Errorf("expected first filename 'logo.png', got '%s'", email.Attachments[0].Filename)
+		}
+
+		// Check second attachment (github icon)
+		if email.Attachments[1].ContentID != "<github.png>" {
+			t.Errorf("expected second ContentID '<github.png>', got '%s'", email.Attachments[1].ContentID)
+		}
+		if email.Attachments[1].Filename != "github.png" {
+			t.Errorf("expected second filename 'github.png', got '%s'", email.Attachments[1].Filename)
+		}
+	}
+
+	if email.HTML == "" {
+		t.Error("expected HTML body, got empty")
+	}
+	if email.Text == "" {
+		t.Error("expected Text body, got empty")
+	}
+}

--- a/internal/adapters/smtp/server.go
+++ b/internal/adapters/smtp/server.go
@@ -180,20 +180,31 @@ func parseMultipartBody(bodyData []byte, boundary string, attachments []domain.A
 		pctype := part.Header.Get("Content-Type")
 		lowerDisp := strings.ToLower(disp)
 
+		// Parse content type to determine if this is text/plain, text/html, or nested multipart
+		mediatype, params, err := mime.ParseMediaType(pctype)
+
 		// Check if this is an attachment
-		if strings.HasPrefix(lowerDisp, "attachment") || (strings.HasPrefix(lowerDisp, "inline") && part.FileName() != "") {
-			filename := part.FileName()
+		// Some clients (like Vaultwarden) put the filename in the Content-Type header
+		filename := part.FileName()
+		if filename == "" && err == nil {
+			filename = params["name"]
+		}
+
+		isAttachment := strings.HasPrefix(lowerDisp, "attachment") ||
+			(strings.HasPrefix(lowerDisp, "inline") && filename != "") ||
+			filename != ""
+
+		if isAttachment {
 			if filename == "" {
 				filename = "attachment"
 			}
+
 			attachments = append(attachments, domain.Attachment{
 				Filename:    filename,
 				Content:     slurp,
 				ContentType: pctype,
 			})
 		} else {
-			// Parse content type to determine if this is text/plain, text/html, or nested multipart
-			mediatype, params, err := mime.ParseMediaType(pctype)
 			if err == nil && strings.HasPrefix(mediatype, "multipart/") {
 				// This is a nested multipart, recurse
 				nestedBoundary := params["boundary"]

--- a/internal/adapters/smtp/server.go
+++ b/internal/adapters/smtp/server.go
@@ -186,7 +186,11 @@ func parseMultipartBody(bodyData []byte, boundary string, attachments []domain.A
 			if filename == "" {
 				filename = "attachment"
 			}
-			attachments = append(attachments, domain.Attachment{Filename: filename, Content: slurp})
+			attachments = append(attachments, domain.Attachment{
+				Filename:    filename,
+				Content:     slurp,
+				ContentType: pctype,
+			})
 		} else {
 			// Parse content type to determine if this is text/plain, text/html, or nested multipart
 			mediatype, params, err := mime.ParseMediaType(pctype)

--- a/internal/adapters/smtp/server.go
+++ b/internal/adapters/smtp/server.go
@@ -190,19 +190,27 @@ func parseMultipartBody(bodyData []byte, boundary string, attachments []domain.A
 			filename = params["name"]
 		}
 
+		contentID := part.Header.Get("Content-ID")
+
 		isAttachment := strings.HasPrefix(lowerDisp, "attachment") ||
-			(strings.HasPrefix(lowerDisp, "inline") && filename != "") ||
-			filename != ""
+			(strings.HasPrefix(lowerDisp, "inline") && (filename != "" || contentID != "")) ||
+			filename != "" ||
+			contentID != ""
 
 		if isAttachment {
 			if filename == "" {
-				filename = "attachment"
+				if contentID != "" {
+					filename = strings.Trim(contentID, "<>")
+				} else {
+					filename = "attachment"
+				}
 			}
-
+			
 			attachments = append(attachments, domain.Attachment{
 				Filename:    filename,
 				Content:     slurp,
 				ContentType: pctype,
+				ContentID:   contentID,
 			})
 		} else {
 			if err == nil && strings.HasPrefix(mediatype, "multipart/") {

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -34,6 +34,22 @@ func (s *Service) HandleEmail(email domain.Email) error {
 	if err := email.Validate(); err != nil {
 		return err
 	}
+	attachmentMeta := make([]map[string]any, 0, len(email.Attachments))
+	for _, a := range email.Attachments {
+		attachmentMeta = append(attachmentMeta, map[string]any{
+			"filename":     a.Filename,
+			"content_type": a.ContentType,
+			"size":         len(a.Content),
+		})
+	}
+	s.logger.Debug("handle_email_start", map[string]any{
+		"from":        email.From,
+		"to":          email.To,
+		"subject":     email.Subject,
+		"text_body":   email.Text,
+		"html_body":   email.HTML,
+		"attachments": attachmentMeta,
+	})
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
 	defer cancel()
 	done := make(chan error, 1)

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -43,12 +43,12 @@ func (s *Service) HandleEmail(email domain.Email) error {
 		})
 	}
 	s.logger.Debug("handle_email_start", map[string]any{
-		"from":        email.From,
-		"to":          email.To,
-		"subject":     email.Subject,
-		"text_body":   email.Text,
-		"html_body":   email.HTML,
-		"attachments": attachmentMeta,
+		"from":            email.From,
+		"to":              email.To,
+		"subject":         email.Subject,
+		"text_body_size":  len(email.Text),
+		"html_body_size":  len(email.HTML),
+		"attachments":     attachmentMeta,
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
 	defer cancel()

--- a/internal/app/service_bench_test.go
+++ b/internal/app/service_bench_test.go
@@ -15,6 +15,7 @@ type benchLogger struct{}
 
 func (benchLogger) Info(string, map[string]any)  {}
 func (benchLogger) Error(string, map[string]any) {}
+func (benchLogger) Debug(string, map[string]any) {}
 
 func BenchmarkHandleEmail(b *testing.B) {
 	svc := NewService(benchSender{}, benchLogger{}, time.Second)

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -16,6 +16,7 @@ type nopLogger struct{}
 
 func (nopLogger) Info(string, map[string]any)  {}
 func (nopLogger) Error(string, map[string]any) {}
+func (nopLogger) Debug(string, map[string]any) {}
 
 func TestHandleEmail_OK(t *testing.T) {
 	svc := NewService(fakeSender{}, nopLogger{}, time.Second)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -29,6 +30,9 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("RESEND_API_KEY is required")
 	}
 	addr := getenv("SMTP_LISTEN_ADDR", ":2525")
+	if len(addr) > 0 && addr[0] != ':' && !strings.Contains(addr, ":") {
+		addr = ":" + addr
+	}
 	timeoutStr := getenv("SEND_TIMEOUT_SECONDS", "15")
 	tSec, err := strconv.Atoi(timeoutStr)
 	if err != nil || tSec <= 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,9 @@ func Load() (Config, error) {
 	}
 	addr := getenv("SMTP_LISTEN_ADDR", ":2525")
 	if len(addr) > 0 && addr[0] != ':' && !strings.Contains(addr, ":") {
-		addr = ":" + addr
+		if _, err := strconv.Atoi(addr); err == nil {
+			addr = ":" + addr
+		}
 	}
 	timeoutStr := getenv("SEND_TIMEOUT_SECONDS", "15")
 	tSec, err := strconv.Atoi(timeoutStr)

--- a/internal/domain/email.go
+++ b/internal/domain/email.go
@@ -64,6 +64,7 @@ type Attachment struct {
 	Filename    string
 	Content     []byte
 	ContentType string
+	ContentID   string
 }
 
 // Tag represents provider-specific metadata tags for analytics or categorization.

--- a/internal/domain/email.go
+++ b/internal/domain/email.go
@@ -61,8 +61,9 @@ func NewEmail(from string, to []string, subject, text, html string, headers map[
 
 // Attachment represents a file attachment with its filename and content.
 type Attachment struct {
-	Filename string
-	Content  []byte
+	Filename    string
+	Content     []byte
+	ContentType string
 }
 
 // Tag represents provider-specific metadata tags for analytics or categorization.

--- a/internal/domain/ports.go
+++ b/internal/domain/ports.go
@@ -12,4 +12,5 @@ type OutboundEmailSender interface {
 type MessageLogger interface {
 	Info(msg string, fields map[string]any)
 	Error(msg string, fields map[string]any)
+	Debug(msg string, fields map[string]any)
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -36,6 +36,11 @@ func (l *StdLogger) Error(msg string, fields map[string]any) {
 	l.L.LogAttrs(context.Background(), slog.LevelError, msg, l.mapAttrs(fields)...)
 }
 
+// Debug logs a message at the debug level with optional structured fields provided as a map.
+func (l *StdLogger) Debug(msg string, fields map[string]any) {
+	l.L.LogAttrs(context.Background(), slog.LevelDebug, msg, l.mapAttrs(fields)...)
+}
+
 // NewConfiguredLogger creates a new slog.Logger configured based on environment variables.
 // It uses JSON handler for cloud environments and text handler for local development.
 // Log level is controlled by LOG_LEVEL environment variable (default: INFO).


### PR DESCRIPTION
## Fix
- Attachments weren't being sent correctly; they weren't included/extracted as inline attachments. (in my case from vaultwarden)

## Changes

- Added debug-level logging to the `MessageLogger` interface and implemented the `Debug` method
- Integrated debug logging in `Service.HandleEmail` and `resendclient.Client.Send` 
- Expanded the `Attachment` struct to include `ContentType` and `ContentID` fields, and ensured these are parsed and populated correctly from incoming emails
- Updated the Resend client to send these new attachment metadata fields when constructing outbound requests.

### Configuration

- Refined SMTP listener address parsing in `config.Load` to automatically prepend a colon if missing, ensuring consistent address formatting.